### PR TITLE
fix: correct platform override logic in sendStatement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.2|^8.3|^8.4",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
-        "msaaq/nelc-xapi-php-sdk": "^1.2|^1.3|^1.4"
+        "msaaq/nelc-xapi-php-sdk": "^1.2|^1.3|^1.4|^1.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Nelc.php
+++ b/src/Nelc.php
@@ -27,7 +27,7 @@ class Nelc
 
     public function sendStatement(StatementInterface $statement)
     {
-        if ( ! $this->platformIdentifier) {
+        if ($this->platformIdentifier) {
             $platform = new Platform($this->platformIdentifier, $this->platformName);
         }
 


### PR DESCRIPTION
## Summary
- Fix negated condition in `sendStatement()` that caused global platform to be created when `platformIdentifier` was empty, potentially overriding per-statement platform identity
- The condition `! $this->platformIdentifier` was backwards — it should be `$this->platformIdentifier` to use the global platform only when configured

## Test plan
- [ ] Verify per-statement platform (set via `$statement->setPlatform()`) is used when no global platform is configured
- [ ] Verify global platform overrides statement platform when `NELC_PLATFORM_IDENTIFIER` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)